### PR TITLE
fix(media): surface non-200 API errors instead of swallowing them

### DIFF
--- a/src/media/service.go
+++ b/src/media/service.go
@@ -58,6 +58,8 @@ func Upload(
 		var respErr common.ErrorResponse
 		if decodeErr := json.NewDecoder(resp.Body).Decode(&respErr); decodeErr != nil {
 			err = decodeErr
+		} else {
+			err = &respErr
 		}
 		return common.ID{}, err
 	}
@@ -103,6 +105,8 @@ func RetrieveURL(
 		var respErr common.ErrorResponse
 		if decodeErr := json.NewDecoder(resp.Body).Decode(&respErr); decodeErr != nil {
 			err = decodeErr
+		} else {
+			err = &respErr
 		}
 		return MediaInfo{}, err
 	}
@@ -139,6 +143,8 @@ func Delete(
 		var respErr common.ErrorResponse
 		if decodeErr := json.NewDecoder(resp.Body).Decode(&respErr); decodeErr != nil {
 			err = decodeErr
+		} else {
+			err = &respErr
 		}
 		return common.SuccessResponse{}, err
 	}
@@ -176,6 +182,8 @@ func Download(
 		var respErr common.ErrorResponse
 		if decodeErr := json.NewDecoder(resp.Body).Decode(&respErr); decodeErr != nil {
 			err = decodeErr
+		} else {
+			err = &respErr
 		}
 		return []byte{}, err
 	}


### PR DESCRIPTION
Upload, RetrieveURL, Delete and Download returned a nil error on any
non-200 response from the Graph API (err was only set when decoding the
error body itself failed). Callers therefore received a zero-value
result with no error — e.g. RetrieveURL returned an empty MediaInfo,
and a subsequent Download("") failed with
'Get "": unsupported protocol scheme ""'.

Assign the decoded ErrorResponse to err in the else branch, matching the
pattern already used in template/get.go and business/get.go.
